### PR TITLE
fix: remove PUBLIC_URL from vercel analytics script path

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
       rel="stylesheet" />
     <title>Wallet DM</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <script defer src="%PUBLIC_URL%/_vercel/insights/script.js"></script>
+    <script defer src="/_vercel/insights/script.js"></script>
   </head>
   <body class="h-full">
     <div id="root"></div>


### PR DESCRIPTION
### Description

Vite doesn't use the `%PUBLIC_URL%/...` in index.html and instead just uses `/...`.