### PR TITLE
fix(message-header): pass down truncate to handle long strings

### DIFF
--- a/src/component-library/components/AddressInput/AddressInput.tsx
+++ b/src/component-library/components/AddressInput/AddressInput.tsx
@@ -85,14 +85,14 @@ export const AddressInput = ({
         <ChevronLeftIcon onClick={onLeftIconClick} width={24} />
       </div>
       <form
-        className="flex w-full items-center"
+        className="flex w-full items-center truncate"
         onSubmit={(e) => e.preventDefault()}>
         <div className="mr-2 font-bold text-sm">{t("common.input_label")}:</div>
         {resolvedAddress?.displayAddress && <Avatar {...avatarUrlProps} />}
-        <div className="ml-2 md:ml-4">
+        <div className="ml-2 md:ml-4 truncate">
           {resolvedAddress?.displayAddress ? (
             <div
-              className="font-bold text-md"
+              className="font-bold text-md truncate"
               data-testid="recipient-wallet-address">
               {resolvedAddress.displayAddress}
             </div>
@@ -123,6 +123,7 @@ export const AddressInput = ({
               "max-md:text-xs",
               "h-5",
               subtextColor,
+              "truncate",
             )}
             data-testid="message-to-subtext">
             {subtext


### PR DESCRIPTION
### Description

Uses [truncate](https://tailwindcss.com/docs/text-overflow#truncate) from Tailwind CSS to keep header buttons from being rendered off screen for mobile and tablet views.

| Android Before | Android After | Tablet Before | Tablet After |
| ----- | ----- | ----- | ----- |
| ![](https://github.com/wallet-dm/xmtp-dapp/assets/26950305/94e6d959-c9a4-4eff-862c-6af52ba1bbdc "Android Before") | ![](https://github.com/wallet-dm/xmtp-dapp/assets/26950305/d5049fdd-645e-4381-b033-4c875102efaf "Android After") | ![](https://github.com/wallet-dm/xmtp-dapp/assets/26950305/7c267554-cd33-4a1b-9e84-85a936462d25 "Tablet Before") | ![](https://github.com/wallet-dm/xmtp-dapp/assets/26950305/5d7fb964-851a-4c94-bee8-eb815ce200f5 "Tablet After") |