### PR TITLE
fix: message header for iOS and general layout

### DIFF
--- a/src/component-library/components/AddressInput/AddressInput.tsx
+++ b/src/component-library/components/AddressInput/AddressInput.tsx
@@ -2,7 +2,7 @@ import { ChevronLeftIcon } from "@heroicons/react/outline";
 import { useTranslation } from "react-i18next";
 import { TAILWIND_MD_BREAKPOINT, classNames } from "../../../helpers";
 import useWindowSize from "../../../hooks/useWindowSize";
-import type { ActiveTab } from "../../../store/xmtp";
+import { useXmtpStore, type ActiveTab } from "../../../store/xmtp";
 import { Avatar } from "../Avatar/Avatar";
 
 interface AddressInputProps {
@@ -73,6 +73,7 @@ export const AddressInput = ({
   const subtextColor = isError ? "text-red-600" : "text-gray-500";
   const [width] = useWindowSize();
   const isMobileView = width <= TAILWIND_MD_BREAKPOINT;
+  const conversationTopic = useXmtpStore((s) => s.conversationTopic);
   return (
     <div
       className={classNames(
@@ -134,7 +135,7 @@ export const AddressInput = ({
           </div>
         </div>
       </form>
-      {onRightIconClick && activeTab === "messages" && (
+      {onRightIconClick && activeTab === "messages" && conversationTopic && (
         <button
           type="button"
           className="text-indigo-600 font-bold text-md"

--- a/src/component-library/components/AddressInput/AddressInput.tsx
+++ b/src/component-library/components/AddressInput/AddressInput.tsx
@@ -80,7 +80,7 @@ export const AddressInput = ({
         !resolvedAddress?.displayAddress
           ? "bg-indigo-50 border-b border-indigo-500"
           : "border-b border-gray-200",
-        "flex items-center px-2 md:px-4 py-3 border-l-0 z-10 max-md:h-fit md:max-h-sm w-full h-16",
+        "bg-white flex items-center px-2 md:px-4 py-3 border-l-0 z-10 max-md:h-fit md:max-h-sm w-full h-16",
       )}>
       <div className="max-md:w-fit md:hidden flex w-24 p-0 justify-start">
         <ChevronLeftIcon onClick={onLeftIconClick} width={24} />

--- a/src/component-library/components/AddressInput/AddressInput.tsx
+++ b/src/component-library/components/AddressInput/AddressInput.tsx
@@ -76,6 +76,7 @@ export const AddressInput = ({
   const conversationTopic = useXmtpStore((s) => s.conversationTopic);
   return (
     <div
+      data-testid="address-container"
       className={classNames(
         !resolvedAddress?.displayAddress
           ? "bg-indigo-50 border-b border-indigo-500"

--- a/src/component-library/components/ConversationList/ConversationList.tsx
+++ b/src/component-library/components/ConversationList/ConversationList.tsx
@@ -3,6 +3,7 @@ import { Virtuoso } from "react-virtuoso";
 import { EmptyMessage } from "../EmptyMessage/EmptyMessage";
 import { MessagePreviewCard } from "../MessagePreviewCard/MessagePreviewCard";
 import type { ActiveTab } from "../../../store/xmtp";
+import { EmptyRequest } from "../EmptyRequest/EmptyRequest";
 
 interface ConversationListProps {
   /**
@@ -44,7 +45,9 @@ export const ConversationList = ({
     <div className="w-full overflow-hidden sm:w-full sm:p-4 md:p-8 border border-gray-100 h-full">
       {activeTab === "messages" ? (
         <EmptyMessage setStartedFirstMessage={setStartedFirstMessage} />
-      ) : null}
+      ) : activeTab === "requests" ? (
+        <EmptyRequest />
+      ) : null }
     </div>
   ) : (
     <Virtuoso

--- a/src/component-library/components/ConversationList/ConversationList.tsx
+++ b/src/component-library/components/ConversationList/ConversationList.tsx
@@ -47,7 +47,7 @@ export const ConversationList = ({
         <EmptyMessage setStartedFirstMessage={setStartedFirstMessage} />
       ) : activeTab === "requests" ? (
         <EmptyRequest />
-      ) : null }
+      ) : null}
     </div>
   ) : (
     <Virtuoso

--- a/src/component-library/components/FullConversation/FullConversation.tsx
+++ b/src/component-library/components/FullConversation/FullConversation.tsx
@@ -4,7 +4,6 @@ import { Virtuoso } from "react-virtuoso";
 import { useMemo, useRef, useState } from "react";
 import { useConsent } from "@xmtp/react-sdk";
 import { useXmtpStore } from "../../../store/xmtp";
-import { AddressInput } from "../AddressInput/AddressInput";
 import { AddressInputController } from "../../../controllers/AddressInputController";
 
 interface FullConversationProps {
@@ -83,7 +82,7 @@ export const FullConversation = ({
   const filteredMessages = useMemo(() => {
     const filtered = messages.filter((msg) => msg !== null);
     return [
-      <AddressInputController />,
+      <AddressInputController key="addressInput" />,
       isLoading ? (
         <LoadingMessage key="loading" />
       ) : (

--- a/src/component-library/components/FullConversation/FullConversation.tsx
+++ b/src/component-library/components/FullConversation/FullConversation.tsx
@@ -4,6 +4,8 @@ import { Virtuoso } from "react-virtuoso";
 import { useMemo, useRef, useState } from "react";
 import { useConsent } from "@xmtp/react-sdk";
 import { useXmtpStore } from "../../../store/xmtp";
+import { AddressInput } from "../AddressInput/AddressInput";
+import { AddressInputController } from "../../../controllers/AddressInputController";
 
 interface FullConversationProps {
   messages?: Array<JSX.Element | null>;
@@ -81,6 +83,7 @@ export const FullConversation = ({
   const filteredMessages = useMemo(() => {
     const filtered = messages.filter((msg) => msg !== null);
     return [
+      <AddressInputController />,
       isLoading ? (
         <LoadingMessage key="loading" />
       ) : (
@@ -101,6 +104,7 @@ export const FullConversation = ({
       className="w-full h-full flex flex-col"
       itemContent={(index, message) => message}
       ref={virtuosoRef}
+      topItemCount={1}
     />
   );
 };

--- a/src/component-library/components/HeaderDropdown/HeaderDropdown.tsx
+++ b/src/component-library/components/HeaderDropdown/HeaderDropdown.tsx
@@ -12,10 +12,6 @@ interface HeaderDropdownProps {
    */
   onClick?: () => void;
   /**
-   * What is the recipient input?
-   */
-  recipientInput: string;
-  /**
    * Boolean to determine if screen width is mobile size
    */
   isMobileView?: boolean;
@@ -23,7 +19,6 @@ interface HeaderDropdownProps {
 
 export const HeaderDropdown = ({
   onClick,
-  recipientInput,
   isMobileView,
 }: HeaderDropdownProps) => {
   const { t } = useTranslation();
@@ -63,14 +58,15 @@ export const HeaderDropdown = ({
             {t(`consent.${name}`)}
           </button>
         ))}
-        {(recipientInput || isMobileView) && (
-          <IconButton
-            onClick={() => onClick?.()}
-            label={<PlusIcon color="white" width="20" />}
-            testId="new-message-icon-cta"
-            srText={t("aria_labels.start_new_message") || ""}
-          />
-        )}
+        <IconButton
+          onClick={() => {
+            setActiveTab("messages");
+            onClick?.();
+          }}
+          label={<PlusIcon color="white" width="20" />}
+          testId="new-message-icon-cta"
+          srText={t("aria_labels.start_new_message") || ""}
+        />
       </div>
     </div>
   );

--- a/src/pages/inbox.tsx
+++ b/src/pages/inbox.tsx
@@ -170,7 +170,7 @@ const Inbox: React.FC<{ children?: React.ReactNode }> = () => {
                   ) : (
                     <>
                       {!conversationTopic && activeTab === "messages" && (
-                        <div className="flex" data-testid="address-container">
+                        <div className="flex">
                           <AddressInputController />
                         </div>
                       )}

--- a/src/pages/inbox.tsx
+++ b/src/pages/inbox.tsx
@@ -28,6 +28,7 @@ const Inbox: React.FC<{ children?: React.ReactNode }> = () => {
   const navigate = useNavigate();
   const resetXmtpState = useXmtpStore((state) => state.resetXmtpState);
   const activeMessage = useXmtpStore((state) => state.activeMessage);
+  const conversationTopic = useXmtpStore((state) => state.conversationTopic);
 
   const { client, disconnect } = useClient();
   const [isDragActive, setIsDragActive] = useState(false);
@@ -168,9 +169,11 @@ const Inbox: React.FC<{ children?: React.ReactNode }> = () => {
                     </div>
                   ) : (
                     <>
-                      <div className="flex" data-testid="address-container">
-                        <AddressInputController />
-                      </div>
+                      {!conversationTopic  && activeTab === "messages" && (
+                        <div className="flex" data-testid="address-container">
+                          <AddressInputController />
+                        </div>
+                      )}
                       <div
                         className="h-full overflow-auto flex flex-col"
                         onFocus={() => {

--- a/src/pages/inbox.tsx
+++ b/src/pages/inbox.tsx
@@ -169,7 +169,7 @@ const Inbox: React.FC<{ children?: React.ReactNode }> = () => {
                     </div>
                   ) : (
                     <>
-                      {!conversationTopic  && activeTab === "messages" && (
+                      {!conversationTopic && activeTab === "messages" && (
                         <div className="flex" data-testid="address-container">
                           <AddressInputController />
                         </div>


### PR DESCRIPTION
### Description

Changes some behavior of the message header for iOS scrolls and general behavior,
- The AddressInputController now conditionally displays if no convo topic is present and the active tab is messages.
- The + icon always displays and now navigates users to the messages tab.
- The AddressInputController when there is a conversation topic now displays as the top item of the Virtuoso list for better scroll behavior on iOS and a white background was added to this element.
- Block & Unblock text buttons now only display on active conversations and not while crafting a new message thread.
- Brought back the `<EmptyRequest />` on the requests tab previously removed by mistake in #11.
